### PR TITLE
Allow empty value at payment_bank_name, payment_branch_brnach_name

### DIFF
--- a/ganb_corporate_client/models/va_transaction.py
+++ b/ganb_corporate_client/models/va_transaction.py
@@ -384,8 +384,6 @@ class VaTransaction(object):
             raise ValueError("Invalid value for `payment_bank_name`, must not be `None`")  # noqa: E501
         if payment_bank_name is not None and len(payment_bank_name) > 30:
             raise ValueError("Invalid value for `payment_bank_name`, length must be less than or equal to `30`")  # noqa: E501
-        if payment_bank_name is not None and len(payment_bank_name) < 1:
-            raise ValueError("Invalid value for `payment_bank_name`, length must be greater than or equal to `1`")  # noqa: E501
 
         self._payment_bank_name = payment_bank_name
 
@@ -413,8 +411,6 @@ class VaTransaction(object):
             raise ValueError("Invalid value for `payment_branch_name`, must not be `None`")  # noqa: E501
         if payment_branch_name is not None and len(payment_branch_name) > 15:
             raise ValueError("Invalid value for `payment_branch_name`, length must be less than or equal to `15`")  # noqa: E501
-        if payment_branch_name is not None and len(payment_branch_name) < 1:
-            raise ValueError("Invalid value for `payment_branch_name`, length must be greater than or equal to `1`")  # noqa: E501
 
         self._payment_branch_name = payment_branch_name
 

--- a/ganb_personal_client/models/va_transaction.py
+++ b/ganb_personal_client/models/va_transaction.py
@@ -384,8 +384,6 @@ class VaTransaction(object):
             raise ValueError("Invalid value for `payment_bank_name`, must not be `None`")  # noqa: E501
         if payment_bank_name is not None and len(payment_bank_name) > 30:
             raise ValueError("Invalid value for `payment_bank_name`, length must be less than or equal to `30`")  # noqa: E501
-        if payment_bank_name is not None and len(payment_bank_name) < 1:
-            raise ValueError("Invalid value for `payment_bank_name`, length must be greater than or equal to `1`")  # noqa: E501
 
         self._payment_bank_name = payment_bank_name
 
@@ -413,8 +411,6 @@ class VaTransaction(object):
             raise ValueError("Invalid value for `payment_branch_name`, must not be `None`")  # noqa: E501
         if payment_branch_name is not None and len(payment_branch_name) > 15:
             raise ValueError("Invalid value for `payment_branch_name`, length must be less than or equal to `15`")  # noqa: E501
-        if payment_branch_name is not None and len(payment_branch_name) < 1:
-            raise ValueError("Invalid value for `payment_branch_name`, length must be greater than or equal to `1`")  # noqa: E501
 
         self._payment_branch_name = payment_branch_name
 


### PR DESCRIPTION
VaTransaction.payment_bank_name, VaTransaction.payment_branch_name returns an empty value from sunabar. I don't know why.
These columns are required in the documantation(https://github.com/gmoaozora/gmo-aozora-api-python/blob/master/docs/corporate/VaTransaction.md).
I think this fix is required to use the SDK with sunabar.
